### PR TITLE
Clarify problem topological sort is solving

### DIFF
--- a/_sources/backpropagate.rst.txt
+++ b/_sources/backpropagate.rst.txt
@@ -65,7 +65,7 @@ cycles is a consequence of the choice that every Function must create a
 new variable.
 
 The topological ordering of a directed acyclic graph is an ordering
-that ensures no node comes before after its ancestor, e.g. in our
+that ensures no node is processed after its ancestor, e.g. in our
 example that the left node cannot be processed before the top or
 bottom node. The ordering may not be unique, and it does not tell us
 whether to process the top or bottom node first.


### PR DESCRIPTION
- fix typo: remove "before" in "before after"
  + I think this is right! Maybe we just keep the "before" language, and drop the "after".
- used processed language for consistency