### PR TITLE
Fix typo in cuda docs

### DIFF
--- a/_sources/cuda.rst.txt
+++ b/_sources/cuda.rst.txt
@@ -34,7 +34,7 @@ on to a notebook:
 
 You can run your tests with the following command:
 
->>> python -m pytest -m test3_3
+>>> python -m pytest -m task3_3
 
 
 


### PR DESCRIPTION
pytest tag `test3_3` doesn't exist, `task3_3` does