### PR TITLE
Update link to Numba parallel docs + fix tiny typo

### DIFF
--- a/module3/module3/index.html
+++ b/module3/module3/index.html
@@ -1380,7 +1380,7 @@ Instead you will only change the core higher-order operations code.</p>
 <p>This task requires basic familiarity with Numba <code>prange</code>.</p>
 <p>Be sure to very carefully read the section on
 parallelism,
-<a href="https://numba.pydata.org/numba-doc/latest/user/parallel.html">Numba</a>.</p>
+<a href="https://numba.readthedocs.io/en/stable/user/parallel.html">Numba</a>.</p>
 </div>
 <p>The main backend for our codebase are the three functions <code>map</code>,
 <code>zip</code>, and <code>reduce</code>. If we can speed up these three, everything we

--- a/module4/module4/index.html
+++ b/module4/module4/index.html
@@ -1366,7 +1366,7 @@ software framework. In particular, we are going to build an image
 recognition system. We will do this by build the infrastructure for a
 version of LeNet on MNIST: a classic convolutional neural network (CNN)
 for digit recognition, and for a 1D conv for NLP sentiment classification.</p>
-<p>You need the files from previous assignments, so maker sure to pull
+<p>You need the files from previous assignments, so make sure to pull
 them over to your new repo. We recommend you to get familiar with
 tensor.py, since you might find some of those functions useful for
 implementing this Module.</p>


### PR DESCRIPTION
The URL Numba docs are hosted at have changed, the current URL results in a 404 error. Updated URL to the new docs.

<img width="941" height="342" alt="Screenshot 2025-09-16 at 15 33 50" src="https://github.com/user-attachments/assets/ba3586d1-d98b-4faf-8c27-a10f9139292f" />

Also fixed a tiny typo on the Networks page ("maker" instead of "make")